### PR TITLE
Accept + in usernames for email addresses

### DIFF
--- a/src/jira.js
+++ b/src/jira.js
@@ -671,8 +671,9 @@ export default class JiraApi {
    */
   getUsersIssues(username, open) {
     const openJql = open ? ' AND status in (Open, \'In Progress\', Reopened)' : '';
+    const escapedUsername = username.replace('+', '\\u002B').replace('@', '\\u0040');
     return this.searchJira(
-      `assignee = ${username.replace('@', '\\u0040')}${openJql}`, {});
+      `assignee = ${escapedUsername}${openJql}`, {});
   }
 
   /** Add issue to Jira


### PR DESCRIPTION
'+' is a reserved JQL character, so we have to escape it too for email addresses